### PR TITLE
Make base execution robust and code clearer

### DIFF
--- a/alidock/helpers/init.sh.j2
+++ b/alidock/helpers/init.sh.j2
@@ -3,9 +3,22 @@
 # Init script for alidock. Will run inside the container. Auto-generated.
 
 # Log into the shared directory to allow debug
-exec &> >(tee "{{sharedDir}}/.init.log")
+exec &> >(tee "{{sharedDir}}/{{logRelative}}")
 
 cd /
+
+# Change global prompt
+cat > /etc/profile.d/alidock.sh <<\EOF
+#!/bin/bash
+[[ $_ALIDOCK_ENV ]] && return 0;
+function _alidock_ps1() {
+  local RV=$?
+  [[ $RV != 0 ]] && echo -n "$RV|"
+}
+export -f _alidock_ps1
+export PS1='`_alidock_ps1`[alidock] \w \$> '
+export _ALIDOCK_ENV=1
+EOF
 
 # Create server's SSH key
 rm -f /etc/ssh/ssh_host_rsa_key
@@ -30,19 +43,6 @@ chown -R "{{userName}}" "{{sharedDir}}/.ssh"
 # Silence login messages ("Last login:...")
 touch "{{sharedDir}}/.hushlogin"
 chown "{{userName}}" "{{sharedDir}}/.hushlogin"
-
-# Change global prompt
-cat > /etc/profile.d/alidock.sh <<\EOF
-#!/bin/bash
-[[ $_ALIDOCK_ENV ]] && return 0;
-function _alidock_ps1() {
-  local RV=$?
-  [[ $RV != 0 ]] && echo -n "$RV|"
-}
-export -f _alidock_ps1
-export PS1='`_alidock_ps1`[alidock] \w \$> '
-export _ALIDOCK_ENV=1
-EOF
 
 # Create skeleton .bashrc/.bash_profile
 pushd "{{sharedDir}}"

--- a/alidock/log.py
+++ b/alidock/log.py
@@ -1,9 +1,23 @@
 import sys
 
-def info(msg):
-    sys.stderr.write("\033[32m" + msg + "\033[m\n")
-    sys.stderr.flush()
+class Log(object):
+    green = "32"
+    red = "31"
 
-def error(msg):
-    sys.stderr.write("\033[31m" + msg + "\033[m\n")
-    sys.stderr.flush()
+    def __init__(self):
+        self.quiet = False
+
+    def setQuiet(self, quiet=True):
+        self.quiet = quiet
+
+    def printColor(self, colEsc, msg):
+        if self.quiet:
+            return
+        sys.stderr.write("\033[" + colEsc + "m" + msg + "\033[m\n")
+        sys.stderr.flush()
+
+    def info(self, msg):
+        self.printColor(self.green, msg)
+
+    def error(self, msg):
+        self.printColor(self.red, msg)


### PR DESCRIPTION
* Handle and print exceptions more nicely
* Refactor log as an external class to avoid using globals (pylint)
* Move all printout messages outside of AliDock
* Always check if SSH works to make `alidock start && alidock enter` work
* Increase SSH wait timeout
* Add quiet mode (`--quiet`)
* Use less `if` branches (pylint)