### PR TITLE
Add support for nVidia runtime

### DIFF
--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -142,7 +142,7 @@ class AliDock(object):
             nul = open(os.devnull, "w")
             subprocess.check_call(initOutsideShPath, stdout=nul, stderr=nul)
         except subprocess.CalledProcessError:
-            raise AliDockError("fatal error running the host initialization script: "
+            raise AliDockError("the host initialization script failed, "
                                "check {log}".format(
                                    log=os.path.join(self.conf["dirOutside"], ".alidock-host.log")))
 
@@ -160,7 +160,7 @@ class AliDock(object):
                 dockRuntime = "nvidia"
                 dockEnvironment = ["NVIDIA_VISIBLE_DEVICES=all"]
             else:
-                raise AliDockError("fatal error: can't find nvidia runtime in your docker")
+                raise AliDockError("cannot find the nvidia runtime in your Docker installation")
 
         # Start container with that script
         self.cli.containers.run(self.conf["imageName"],

--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -41,7 +41,7 @@ class AliDock(object):
             "dirOutside"       : "~/alidock",
             "updatePeriod"     : 43200,
             "dontUpdateImage"  : False,
-            "useNVidiaRuntime" : False
+            "useNvidiaRuntime" : False
         }
         self.parseConfig()
         self.overrideConfig(overrideConf)
@@ -154,13 +154,12 @@ class AliDock(object):
         if platform.system() != "Linux":
             dockMounts.append(Mount("/persist", "persist-"+self.conf["dockName"], type="volume"))
 
-        # If requested check for nvidia runtime in docker. Configure env and runtime, if found
-        if self.conf["useNVidiaRuntime"]:
+        if self.conf["useNvidiaRuntime"]:
             if self.hasRuntime("nvidia"):
                 dockRuntime = "nvidia"
                 dockEnvironment = ["NVIDIA_VISIBLE_DEVICES=all"]
             else:
-                raise AliDockError("cannot find the nvidia runtime in your Docker installation")
+                raise AliDockError("cannot find the NVIDIA runtime in your Docker installation")
 
         # Start container with that script
         self.cli.containers.run(self.conf["imageName"],
@@ -311,9 +310,9 @@ def entrypoint():
     argp.add_argument("--no-update-image", dest="dontUpdateImage", default=None,
                       action="store_true",
                       help="Do not update the Docker image [dontUpdateImage]")
-    argp.add_argument("--nvidia", dest="useNVidiaRuntime", default=None,
+    argp.add_argument("--nvidia", dest="useNvidiaRuntime", default=None,
                       action="store_true",
-                      help="Launch container using the nVidia Docker runtime [useNVidiaRuntime]")
+                      help="Launch container using the NVIDIA Docker runtime [useNvidiaRuntime]")
 
     argp.add_argument("action", default="enter", nargs="?",
                       choices=["enter", "root", "exec", "start", "status", "stop"],

--- a/alidock/helpers/init-outside.sh.j2
+++ b/alidock/helpers/init-outside.sh.j2
@@ -7,8 +7,6 @@ exec &> >(tee "{{alidockDir}}/{{logFile}}")
 
 cd /
 
-
-false
 {% if operatingSystem == "Darwin" %}
 # macOS: exclude aliBuild directory from Spotlight searches
 # This also migrates an existing .sw directory to .sw.noindex and creates proper

--- a/alidock/helpers/init-outside.sh.j2
+++ b/alidock/helpers/init-outside.sh.j2
@@ -7,6 +7,8 @@ exec &> >(tee "{{alidockDir}}/{{logFile}}")
 
 cd /
 
+
+false
 {% if operatingSystem == "Darwin" %}
 # macOS: exclude aliBuild directory from Spotlight searches
 # This also migrates an existing .sw directory to .sw.noindex and creates proper


### PR DESCRIPTION
Just as simple as this. It works (see #46).
This will enable the nVidia runtime in **every** container launched by alidock (not a single additional line in Dockerfile) if the nvidia-docker runtime is installed in docker, die if not present.

Also:
 - Prepare for possible environment configuration at container launch (`docker -e`, to be clear)
 - Prepare for possible custom runtimes choices (very unilkely, ATM)
by explicitly passing those two parameters to the `container.run(...)` API call. 