### PR TITLE
Add timeout to getent for cloudflared

### DIFF
--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -85,7 +85,7 @@ class AliDock(object):
                 "-i", os.path.join(self.conf["dirOutside"], ".alidock-ssh", "alidock.pem")]
 
     def waitSshUp(self):
-        for _ in range(0, 40):
+        for _ in range(0, 50):
             try:
                 nul = open(os.devnull, "w")
                 subprocess.check_call(self.getSshCommand() + ["-T", "/bin/true"],

--- a/alidock/helpers/init-inside.sh.j2
+++ b/alidock/helpers/init-inside.sh.j2
@@ -106,7 +106,7 @@ popd
 
 # Check if we can resolve domain names; if we can't we start cloudflared
 ERR=0
-getent hosts www.google.com &> /dev/null || ERR=$?
+timeout -s9 8 getent hosts www.google.com &> /dev/null || ERR=$?
 if [[ $ERR != 0 ]]; then
   nohup cloudflared proxy-dns &> /dev/null &
   printf '# Use cloudflared\nnameserver 127.0.0.1\n' > /etc/resolv.conf


### PR DESCRIPTION
`cloudflared` will eventually kick in, but with the current configuration the
`alidock` command times out. This change makes `alidock` work truly
transparently when Docker is using weird DNS settings.