### PR TITLE
Make git more friendly (editor, pager, colors)

### DIFF
--- a/alidock/helpers/init-inside.sh.j2
+++ b/alidock/helpers/init-inside.sh.j2
@@ -38,7 +38,7 @@ function _alidock_ps1() {
 }
 export -f _alidock_ps1
 
-function aliBuildUpdateMirrors() {
+function aliBuildUpdateMirrors() {(
   for REPO in $ALIBUILD_WORK_DIR/MIRROR/*/objects; do
     [[ -d $REPO ]] || continue
     REPO=$(dirname "$REPO")
@@ -47,14 +47,19 @@ function aliBuildUpdateMirrors() {
       git remote update
     popd &> /dev/null
   done
-}
+)}
 export -f aliBuildUpdateMirrors
 
 export PS1='`_alidock_ps1`[{{dockName}}] \w \$> '
 [[ -d /persist ]] && export ALIBUILD_WORK_DIR="/persist/sw" || export ALIBUILD_WORK_DIR="$HOME/.sw"
 type alienv &> /dev/null && eval "$(alienv shell-helper)"
+
+export GIT_PAGER=cat
+type nano &> /dev/null && export GIT_EDITOR=nano
+
 if [[ $(id -u) == {{userId}} ]]; then
   git config --global credential.helper 'cache --timeout 86400 --socket /var/git-creds-{{userId}}/socket'
+  git config --global color.ui auto
 fi
 type hub &> /dev/null && alias git=hub
 export _ALIDOCK_ENV=1

--- a/dock/Dockerfile
+++ b/dock/Dockerfile
@@ -1,6 +1,6 @@
 FROM alisw/slc7-builder
 RUN rpmdb --rebuilddb && yum clean all && rm -rf /var/cache/yum && \
-    yum -y install xcalc tmux htop bash-completion tig pigz && \
+    yum -y install xcalc tmux htop bash-completion tig pigz nano && \
     yum clean all && rm -rf /var/cache/yum
 RUN pip install alibuild==v1.5.4rc6
 RUN cd /tmp && \


### PR DESCRIPTION
* Default editor: `nano`
* Default pager: `cat` (favour graphical terminals)
* Git uses colors by default

Moreover, we fix a problem with the `aliBuildUpdateMirrors` script.

This fixes #49.