### PR TITLE
Add grace time before updating from PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ alidock.egg-info
 *.pyc
 *.swp
 /dist
+.vscode


### PR DESCRIPTION
Only consider PyPI versions older than 15 minutes. We allow all PyPI caches to
sync to prevent a problem where a newly updated version of alidock is detected
by the main executable, but not by the automatically invoked pip, causing a
terrible (though converging) auto-update loop.