### PR TITLE
Expand path to pem key.

### DIFF
--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -87,7 +87,7 @@ class AliDock(object):
                 "-oForwardX11Trusted=no", "-oUserKnownHostsFile=/dev/null", "-oLogLevel=QUIET",
                 "-oStrictHostKeyChecking=no", "-oForwardX11Timeout=596h",
                 "-i", os.path.join(os.path.expanduser(self.conf["dirOutside"]),
-                ".alidock-ssh", "alidock.pem")]
+                                   ".alidock-ssh", "alidock.pem")]
 
     def waitSshUp(self):
         for _ in range(0, 50):

--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -86,7 +86,8 @@ class AliDock(object):
         return ["ssh", "localhost", "-p", str(sshPort), "-Y", "-F/dev/null",
                 "-oForwardX11Trusted=no", "-oUserKnownHostsFile=/dev/null", "-oLogLevel=QUIET",
                 "-oStrictHostKeyChecking=no", "-oForwardX11Timeout=596h",
-                "-i", os.path.join(os.path.expanduser(self.conf["dirOutside"]), ".alidock-ssh", "alidock.pem")]
+                "-i", os.path.join(os.path.expanduser(self.conf["dirOutside"]),
+                ".alidock-ssh", "alidock.pem")]
 
     def waitSshUp(self):
         for _ in range(0, 50):

--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -86,7 +86,7 @@ class AliDock(object):
         return ["ssh", "localhost", "-p", str(sshPort), "-Y", "-F/dev/null",
                 "-oForwardX11Trusted=no", "-oUserKnownHostsFile=/dev/null", "-oLogLevel=QUIET",
                 "-oStrictHostKeyChecking=no", "-oForwardX11Timeout=596h",
-                "-i", os.path.join(self.conf["dirOutside"], ".alidock-ssh", "alidock.pem")]
+                "-i", os.path.join(os.path.expanduser(self.conf["dirOutside"]), ".alidock-ssh", "alidock.pem")]
 
     def waitSshUp(self):
         for _ in range(0, 50):


### PR DESCRIPTION
When running "alidock" I get the following error:

Warning: Identity file ~/alidock/.alidock-ssh/alidock.pem not accessible: No such file or directory.

But the key is there, with the right permissions. 
Expanding the path fixes.