### PR TITLE
Add support for CVMFS in alidock container

### DIFF
--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -46,7 +46,8 @@ class AliDock(object):
             "dontUpdateImage"   : False,
             "dontUpdateAlidock" : False,
             "useNvidiaRuntime"  : False,
-            "mount"             : []
+            "mount"             : [],
+            "cvmfs"             : False
         }
         self.parseConfig()
         self.overrideConfig(overrideConf)
@@ -181,6 +182,12 @@ class AliDock(object):
         dockMounts = [Mount(self.dirInside, outDir, type="bind", consistency="cached")]
         if platform.system() != "Linux":
             dockMounts.append(Mount("/persist", "persist-"+self.conf["dockName"], type="volume"))
+
+        if self.conf["cvmfs"]:
+            dockMounts.append(Mount(source="/cvmfs",
+                                    target="/cvmfs",
+                                    type="bind",
+                                    propagation="shared" if platform.system() == "Linux" else None))
 
         dockMounts += self.getUserMounts()  # user-defined mounts
 
@@ -373,6 +380,9 @@ def entrypoint():
     argp.add_argument("--nvidia", dest="useNvidiaRuntime", default=None,
                       action="store_true",
                       help="Launch container using the NVIDIA Docker runtime [useNvidiaRuntime]")
+    argp.add_argument("--cvmfs", dest="cvmfs", default=None,
+                      action="store_true",
+                      help="Mount CVMFS inside the container [cvmfs]")
 
     argp.add_argument("action", default="enter", nargs="?",
                       choices=["enter", "root", "exec", "start", "status", "stop"],
@@ -380,6 +390,7 @@ def entrypoint():
 
     argp.add_argument("shellCmd", nargs=argparse.REMAINDER,
                       help="Command to execute in the container (works with exec)")
+
 
     args = argp.parse_args()
 


### PR DESCRIPTION
This PR will add:
 - `--cvmfs` flag availability to mount `/cvmfs` inside the container (#67 )

Rationale: easiest assumptions made, can be discussed
 - To check CVMFS availability on the system I only test `/cvmfs`
```python
      os.path.isdir("/cvmfs")  # hardcoded
```
This is indeed not general and does not support a scenario where `/cvmfs` is mounted somewhere else in your system.
 - It tests the distro via `platform.system()` and sets the `propagation=shared` flag accordingly - 
 - Already tested by @dberzano, but re-tested: on Linux, `:shared` flag does not bother you in case of FUSE-mounted CVFMS: 
```bash
      sudo mount -t cvmfs
```