### PR TITLE
Force lowercase of user login for windows systems

### DIFF
--- a/alidock/util.py
+++ b/alidock/util.py
@@ -32,7 +32,7 @@ if hasattr(os, "getuid"):
     USERID = os.getuid()  # pylint: disable=no-member
 else:
     HASH = md5()
-    HASH.update(os.getlogin().encode())
+    HASH.update(os.getlogin().lower().encode())
     USERID = 10000 + int(HASH.hexdigest()[2:5], 16)
     del HASH
 


### PR DESCRIPTION
For some reason, the capitalisation of usernames on windows can change for the same user.
The current approach creates docker volumes based on the hash of the username, so changes
in capitalisation can cause new image/volume names.

This change ensures consistent hashes and USERID for case where capitalisation of user ID differs.

