### PR TITLE
Improve installation, dependencies and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ alidock.egg-info
 *.pyc
 *.swp
 /dist
+/build
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ python:
 install: |
   set -e
   set -o pipefail
-  for PKG in pylint argparse requests PyYaml docker Jinja2 colorama 'twine>=1.11.0' 'setuptools>=38.6.0'; do
-    pip install "$PKG" --upgrade
-  done
-  pip list
+  pip install -e '.[devel]'
+  pip freeze --all
 script: |
   set -e
   set -o pipefail

--- a/alidock-installer.sh
+++ b/alidock-installer.sh
@@ -112,25 +112,20 @@ pinfo "Installing alidock under $VENV_DEST"
 swallow source "$VENV_DEST/bin/activate"
 
 URL=
-DEVEL=
 case "$MODE" in
   default) URL=alidock ;;
   git) URL=git+https://github.com/dberzano/alidock ;;
   devel)
-    URL="$PROG_DIR"
-    if [[ ! -f "$URL/setup.py" ]]; then
+    if [[ ! -f "$PROG_DIR/setup.py" ]]; then
       perr "You did not execute the installer from the development directory"
       exit 4
     fi
-    DEVEL="-e"
+    URL=("-e" "$PROG_DIR[devel]")
   ;;
   *) URL="alidock==$MODE" ;;
 esac
 
-swallow pip install --upgrade ${DEVEL} "${URL}"
-if [[ $DEVEL ]]; then
-  swallow pip install pylint
-fi
+swallow pip install --upgrade "${URL[@]}"
 
 # Patch init scripts for bash and zsh
 SHELL_CHANGED=

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -19,14 +19,15 @@ elif [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_BRANCH == master ]]; then
   DOCKER_REPO=alisw
 fi
 
-if [[ $TRAVIS != true ]]; then
+if [[ $TRAVIS != true && ! $VIRTUAL_ENV ]]; then
   # Not on Travis: try to load alidock's virtualenv (non-fatal)
   source "$HOME/.virtualenvs/alidock/bin/activate" || true
-  type pylint
 fi
+type pylint
 
 # Pylint
-find . -name '*.py' -a -not -name 'setup.py' | xargs pylint
+find . -name '*.py' -a -not -path './dist/*'  \
+                    -a -not -path './build/*' | xargs pylint
 
 # Docker
 if [[ $RUN_DOCK ]]; then

--- a/setup.py
+++ b/setup.py
@@ -1,89 +1,111 @@
+"""Install this Python package.
+"""
+
+# pylint: disable=invalid-name
+
+import re
+import os.path
 from setuptools import setup, find_packages
-from codecs import open
-from os import path
-from glob import glob
 
-setup(
-  name='alidock',
+class Setup(object):
+    """Convenience wrapper (for C.I. purposes) of the `setup()` call form `setuptools`. It
+    automatically fills some of the most obnoxious variables that normally need to be repeated
+    multiple times in several places (for instance, the `README.md` and the `MANIFEST.in`).
+    """
+    def __init__(self, **kw):
+        self.conf = kw
+        self.work_dir = os.path.abspath(os.path.dirname(__file__))
 
-  # LAST-TAG is a placeholder. Automatically replaced at deploy time with the right tag
-  version='LAST-TAG',
+        # Automatically fill `package_data` from `MANIFEST.in`. No need to repeat lists twice
+        assert "package_data" not in self.conf
+        assert "include_package_data" not in self.conf
+        package_data = {}
+        with open(os.path.join(self.work_dir, "MANIFEST.in")) as fp:
+            for line in fp.readlines():
+                line = line.strip()
+                m = re.search(r"include\s+(.+)/([^/]+)", line)
+                assert m
+                module = m.group(1).replace("/", ".")
+                fileName = m.group(2)
+                if not module in package_data:
+                    package_data[module] = []
+                package_data[module].append(fileName)
+        if package_data:
+            self.conf["include_package_data"] = True
+            self.conf["package_data"] = package_data
 
-  description='Run your ALICE environment from a container easily',
+        # Automatically fill the long description from `README.md`. Filter out lines that look like
+        # "badges". See https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
+        assert "long_description" not in self.conf
+        assert "long_description_content_type" not in self.conf
+        with open(os.path.join(self.work_dir, "README.md")) as fp:
+            ld = "\n".join([line for line in fp if not line.startswith("[![")])
+        self.conf["long_description"] = ld
+        self.conf["long_description_content_type"] = "text/markdown"
 
-  # Long description from Markdown -- https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
-  # Filter out lines that look like GitHub "badges"
-  long_description="\n".join([ line for line in open('README.md').read().split("\n") if not line.startswith("[![") ]),
-  long_description_content_type='text/markdown',
+    def __str__(self):
+        return str(self.conf)
+    def __call__(self):
+        setup(**self.conf)
 
-  url='https://github.com/dberzano/alidock',
-  author='Dario Berzano',
-  author_email='dario.berzano@cern.ch',
-  license='GPL',
-  classifiers=[
+SETUP = Setup(
+    name="alidock",
 
-    # How mature is this project? Common values are
-    #   3 - Alpha
-    #   4 - Beta
-    #   5 - Production/Stable
-    'Development Status :: 4 - Beta',
+    # LAST-TAG is a placeholder. Automatically replaced at deploy time with the right tag
+    version="LAST-TAG",
 
-    # Indicate who your project is intended for
-    'Intended Audience :: Education',
-    'Topic :: Scientific/Engineering :: Physics',
+    description="Run your ALICE environment from a container easily",
 
-    # Pick your license as you wish (should match "license" above)
-    'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+    url="https://github.com/dberzano/alidock",
+    author="Dario Berzano",
+    author_email="dario.berzano@cern.ch",
+    license="GPL",
 
-    # Specify the Python versions you support here. In particular, ensure
-    # that you indicate whether you support Python 2, Python 3 or both.
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.7',
+    # See https://pypi.org/classifiers/
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Education",
+        "Intended Audience :: Developers",
+        "Topic :: Scientific/Engineering :: Physics",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.7",
     ],
 
-  # What does your project relate to?
-  keywords='HEP Computing',
+    # What does your project relate to?
+    keywords="HEP computing container docker",
 
-  # You can just specify the packages manually here if your project is
-  # simple. Or you can use find_packages().
-  packages=find_packages(),
+    # You can just specify the packages manually here if your project is simple. Or you can use
+    # find_packages().
+    packages=find_packages(),
 
-  # Alternatively, if you want to distribute just a my_module.py, uncomment
-  # this:
-  #   py_modules=["my_module"],
+    # List run-time dependencies here.  These will be installed by pip when your project is
+    # installed. For an analysis of "install_requires" vs pip's requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=["requests", "PyYaml", "docker", "Jinja2", "colorama"],
 
-  # List run-time dependencies here.  These will be installed by pip when
-  # your project is installed. For an analysis of "install_requires" vs pip's
-  # requirements files see:
-  # https://packaging.python.org/en/latest/requirements.html
-  install_requires=[ "argparse", "requests", "PyYaml", "docker", "Jinja2", "colorama" ],
+    python_requires=">=2.7",
 
-  python_requires='>=2.7',
+    # List additional groups of dependencies here (e.g. development dependencies). You can install
+    # these using the following syntax, for example:
+    # $ pip install -e .[dev,test]
+    extras_require={
+        "devel": ["pylint<=2.2.3", "twine>=1.11.0", "setuptools>=38.6.0"]
+    },
 
-  # List additional groups of dependencies here (e.g. development
-  # dependencies). You can install these using the following syntax,
-  # for example:
-  # $ pip install -e .[dev,test]
-  extras_require={
-  },
+    # Although 'package_data' is the preferred approach, in some case you may need to place data
+    # files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
+    data_files=[],
 
-  # If there are data files included in your packages that need to be
-  # installed, specify them here. Note that you need to specify those files in
-  # MANIFEST.in as well, since Python tools behave inconsistently
-  include_package_data=True,
-  package_data={ "alidock.helpers": ["init.sh.j2"] },
-
-  # Although 'package_data' is the preferred approach, in some case you may
-  # need to place data files outside of your packages. See:
-  # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files
-  # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-  data_files=[],
-
-  # To provide executable scripts, use entry points in preference to the
-  # "scripts" keyword. Entry points provide cross-platform support and allow
-  # pip to create the appropriate form of executable for the target platform.
-  # See: https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/
-  entry_points={
-      "console_scripts": [ "alidock = alidock:entrypoint" ]
-  }
+    # To provide executable scripts, use entry points in preference to the "scripts" keyword. Entry
+    # points provide cross-platform support and allow pip to create the appropriate form of
+    # executable for the target platform. See:
+    # https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/
+    entry_points={
+        "console_scripts": ["alidock = alidock:entrypoint"]
+    }
 )
+
+if __name__ == "__main__":
+    SETUP()


### PR DESCRIPTION
* Avoid duplications in `setup.py` & co.
* Exclude dist, build from Git
* Check `setup.py` with pylint as well
* Add special `[devel]` option for C.I. and local development
* Pin pylint version, fixes #105
* Remove `argparse` dep: part of standard Python distributions
* Do not load virtualenv in local run-tests.sh if already in a virtualenv