### PR TITLE
Fix python executable used for autoupdate

### DIFF
--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -23,7 +23,7 @@ import requests
 from requests.exceptions import RequestException
 from pkg_resources import resource_string, parse_version, require
 from alidock.log import Log
-from alidock.util import splitEsc, getUserId, getUserName, execReturn
+from alidock.util import splitEsc, getUserId, getUserName, execReturn, deactivateVenv
 
 LOG = Log()
 INSTALLER_URL = "https://raw.githubusercontent.com/alidock/alidock/master/alidock-installer.sh"
@@ -337,6 +337,7 @@ class AliDock(object):
         if curModulePath.startswith(virtualenvPath):
             LOG.warning("Updating alidock automatically")
             updateEnv = os.environ
+            deactivateVenv(updateEnv)
             updateEnv["ALIDOCK_ARGS"] = " ".join(sys.argv[1:])
             updateEnv["ALIDOCK_RUN"] = "1"
             os.execvpe("bash",

--- a/alidock/util.py
+++ b/alidock/util.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import re
 import sys
 import platform
@@ -49,6 +50,20 @@ def getUserName():
     casing and purely numerical usernames)."""
     userName = re.sub("[^0-9a-z_-]", "_", os.getlogin().lower())
     return "u" + userName if userName.isdigit() else userName
+
+def deactivateVenv(env):
+    """Given a dictionary with the current environment it cleans it up by removing the current
+    Python virtual environment."""
+    if not "VIRTUAL_ENV" in env:
+        return
+    venvPrefix = os.path.realpath(os.path.expanduser(env["VIRTUAL_ENV"]))
+    for var in ["PYTHONHOME", "PYTHONPATH", "PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]:
+        if not var in env:
+            continue
+        val = os.path.realpath(os.path.expanduser(env[var]))
+        env[var] = ":".join(x for x in val.split(":")
+                            if not os.path.realpath(os.path.expanduser(x)).startswith(venvPrefix))
+    del env["VIRTUAL_ENV"]
 
 if platform.system() == "Windows":
     def execReturn(_, args):

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ SETUP = Setup(
     # these using the following syntax, for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        "devel": ["pylint<=2.2.3", "twine>=1.11.0", "setuptools>=38.6.0"]
+        "devel": ["pylint<=2.3.1", "twine>=1.11.0", "setuptools>=38.6.0"]
     },
 
     # Although 'package_data' is the preferred approach, in some case you may need to place data


### PR DESCRIPTION
Fixes #121. It also bumps pylint to a more recent, but fixed, version