### PR TITLE
Set shared memory size to 1 GB

### DIFF
--- a/alidock/__init__.py
+++ b/alidock/__init__.py
@@ -296,7 +296,8 @@ class AliDock(object):
                                 ports=fwdPorts,
                                 runtime=dockRuntime,
                                 devices=dockDevices,
-                                group_add=addGroups.keys())
+                                group_add=addGroups.keys(),
+                                shm_size="1G")
 
         return True
 


### PR DESCRIPTION
Running code in O2 could require more shared memory than the docker default